### PR TITLE
Update digitales_register runtime to 46

### DIFF
--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,26 @@
+From bc0c47854d7cb1e86839c6ab941a98292cd1eb99 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Tue, 11 Jun 2024 21:43:07 +0300
+Subject: [PATCH] appdata: Update appdata
+
+- Fix appdata papercuts
+---
+ digitales_register.metainfo.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/digitales_register.metainfo.xml b/digitales_register.metainfo.xml
+index 6215c01..48a5b91 100644
+--- a/digitales_register.metainfo.xml
++++ b/digitales_register.metainfo.xml
+@@ -9,7 +9,7 @@
+   <description>
+     <p>
+ Das Digitale Register für Schüler und Eltern, jetzt auch als App verfügbar.
+-Diese inoffizielle App bietet viele gewohnte Funktionen der Web-Version (https://schule.digitalesregister.it),
++Diese inoffizielle App bietet viele gewohnte Funktionen der Web-Version (schule.digitalesregister.it),
+ wie das Ansehen von Hausaufgaben, Mitteilungen, Noten, Zeugnis und Kalender.
+ Darüber hinaus sind weitere Zusatzfunktionen vorhanden:
+ </p>
+--
+libgit2 1.7.2
+

--- a/io.github.mideb.digitales_register.yaml
+++ b/io.github.mideb.digitales_register.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.mideb.digitales_register
 runtime: org.gnome.Platform
-runtime-version: "43"
+runtime-version: "46"
 sdk: org.gnome.Sdk
 command: digitales_register
 finish-args:

--- a/io.github.mideb.digitales_register.yaml
+++ b/io.github.mideb.digitales_register.yaml
@@ -51,3 +51,5 @@ modules:
         url: https://github.com/miDeb/digitales_register/releases/download/v8.2.15/digitales_register-linux-x86_64.tar.gz
         dest: digitales_register
         sha256: 27ecda40fcc197922a9efe64f534cd9d91a8438f050fd8f7704d28354c29439b
+      - type: patch
+        path: fix_appdata.patch


### PR DESCRIPTION
- Update digitales_register runtime to 46 since runtime version 44 has reached end-of-life.
- Fix appdata papercuts.