### PR TITLE
Update io.github.mideb.digitales_register runtime to 46

### DIFF
--- a/io.github.mideb.digitales_register.yaml
+++ b/io.github.mideb.digitales_register.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.mideb.digitales_register
 runtime: org.gnome.Platform
-runtime-version: "43"
+runtime-version: "46"
 sdk: org.gnome.Sdk
 command: digitales_register
 finish-args:


### PR DESCRIPTION
- Update io.github.mideb.digitales_register runtime to 46
- Fix appdata papercuts